### PR TITLE
Remove default configFile option

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -17,7 +17,6 @@ module.exports = class StylelintBarePlugin {
 
         this.options = merge({
             files: '**/*.s?(c|a)ss',
-            configFile: '.stylelintrc',
             formatter: (() => {
                 if ( get(stylelint, 'formatters.string') ) {
                     return stylelint.formatters.string;


### PR DESCRIPTION
If no `configFIle` is passed stylint will try and file it's own config. This change saves overriding the config with package.json.

https://github.com/stylelint/stylelint/blob/master/docs/user-guide/configuration.md#loading-the-configuration-object