### PR TITLE
Use webpack compilation warnings

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -61,7 +61,7 @@ module.exports = class StylelintBarePlugin {
         }).catch((e) => {
             console.error(chalk.red(['', `Error in ${plugin.name}`].join('\n')));
             console.trace(chalk.red(e));
-        }).then(callback);
+        });
     }
     
     report(compilation) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,14 +10,19 @@ const plugin = {
 };
 
 module.exports = class StylelintBarePlugin {
+
     constructor(options = {}) {
         if ( typeof options !== 'undefined' && !isPlainObject(options) ) {
             throw new Error(`${plugin.name} options should be an object`);
         }
 
+        this.warnings = [];
+        this.errors = [];
+
         this.options = merge({
             files: '**/*.s?(c|a)ss',
-            configFile: '.stylelintrc',
+            emitErrors: true,
+            failOnError: false,
             formatter: (() => {
                 if ( get(stylelint, 'formatters.string') ) {
                     return stylelint.formatters.string;
@@ -38,25 +43,48 @@ module.exports = class StylelintBarePlugin {
         }
     }
 
-    apply(compiler) {
-        // Run the linter when required
-        compiler.hooks.run.tapAsync(plugin, this.lint.bind(this));
-        compiler.hooks.watchRun.tapAsync(plugin, this.lint.bind(this));
-
-        // Show the lint formatter output in the next tick (after the stats)
-        compiler.hooks.done.tap(plugin, () => {
-            setTimeout(() => {
-                console.log(this.options.formatter(this.results));
-            }, 0);
-        });
-    }
-
     lint(compilation, callback) {
-        stylelint.lint(this.options).then((linter) => {
+        stylelint.lint(this.options)
+        .then((linter) => {
             this.results = linter.results;
+            if(this.options.emitErrors) {
+                this.errors = this.results.filter((file) => { return file.errored });
+                this.warnings = this.results.filter((file) => { return file.errored && file.warnings && file.warnings.length });
+            } else {
+                this.warnings = this.results.filter((file) => { return file.errored || (file.warnings && file.warnings.length) });
+            }
+
+            (this.options.failOnError && this.errors.length)
+                ? callback(new Error('Failed because of a stylelint error.'))
+                : callback();
+
         }).catch((e) => {
             console.error(chalk.red(['', `Error in ${plugin.name}`].join('\n')));
             console.trace(chalk.red(e));
         }).then(callback);
     }
+    
+    report(compilation) {
+        if(this.errors.length){
+            compilation.errors.push(new Error(this.options.formatter(this.errors)));
+            this.errors = [];
+        }
+        if(this.warnings.length){
+            compilation.warnings.push(new Error(this.options.formatter(this.warnings)));
+            this.warnings = [];
+        }
+    }
+
+    apply(compiler) {
+        // Run the linter when required
+        let linter = this.lint.bind(this);
+        compiler.hooks.run.tapAsync(plugin, linter);
+        compiler.hooks.watchRun.tapAsync(plugin, linter);
+
+        // Show the lint formatter output in the next tick (after the stats)
+        let reporter = this.report.bind(this);
+        let hook = this.options.emitErrors ? 'afterCompile' : 'afterEmit';
+        compiler.hooks[hook].tap(plugin, reporter);
+    }
+    
 }


### PR DESCRIPTION
This commit adds the following config:

* emitErrors: Show stylelint errors as webpack errors (otherwise as web warnings)
* failOnError: Stop compilation on stylelint errors

These two configs match the behaviour of https://github.com/webpack-contrib/stylelint-webpack-plugin

Additionally this update uses webpack compilation errors and warnings rather than just outputting the stylelint formatter string